### PR TITLE
Fix error message in case of DB authentification failure

### DIFF
--- a/GlobalBackendcentreonbroker.php
+++ b/GlobalBackendcentreonbroker.php
@@ -904,7 +904,7 @@ class GlobalBackendcentreonbroker implements GlobalBackendInterface {
                                                                                               PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES utf8"));
             $this->_dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         } catch (PDOException $e) {
-            throw new BackendConnectionProblem(l('errorConnectingMySQL', Array('BACKENDID' => $this->backendId,'MYSQLERR' => $e->getMessage())));
+            throw new BackendConnectionProblem(l('errorConnectingMySQL', Array('BACKENDID' => $this->_backendId,'MYSQLERR' => $e->getMessage())));
         }
     }
 


### PR DESCRIPTION
In case of DB authentification failure, error message is not correctly displayed. Instead, a PHP error about undefined $backendId is displayed (see http://forums.monitoring-fr.org/index.php?topic=8485.0 or http://forum.centreon.com/forum/centreon-ui/centreon-nagvis/16486-ces-engine-broker-nagvis)